### PR TITLE
Handling of NAs in input of lead isotope age model functions 

### DIFF
--- a/R/ASTR_PbIso_AgeModels.R
+++ b/R/ASTR_PbIso_AgeModels.R
@@ -161,16 +161,32 @@ stacey_kramers_1975 <- function(df,
     )$root
   }
 
+  result <- data.frame("model_age_SK75" = rep(NA, nrow(df)), "mu_SK75" = NA, "kappa_SK75" = NA)
+
   # Calculation and clean-up
 
-  model_age <- mapply(model_age_func, df[[ratio_206_204]], df[[ratio_207_204]])
-  model_age <- replace(model_age, model_age <= -10001 * 10^6 | model_age >= t0 - 1 * 10^6, NA)
+  result$model_age_SK75 <- ifelse(
+    is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]) | is.na(df[[ratio_208_204]]),
+    NA_real_,
+    mapply(model_age_func, df[[ratio_206_204]], df[[ratio_207_204]])
+    )
 
-  mu <- (df[[ratio_206_204]] - a0) / (exp(l238 * t0) - exp(l238 * model_age))
-  kappa <- (df[[ratio_208_204]] - c0) / (mu * (exp(l232 * t0) - exp(l232 * model_age)))
+  result$model_age_SK75 <- replace(result$model_age_SK75, result$model_age_SK75 <= -10001 * 10^6 | result$model_age_SK75 >= t0 - 1 * 10^6, NA)
 
-  result <- data.frame("model_age_SK75" = model_age * 10^-6, "mu_SK75" = mu, "kappa_SK75" = kappa) %>%
-    round(3)
+  result$mu_SK75 <-  ifelse(
+    is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]) | is.na(df[[ratio_208_204]]),
+    NA_real_,
+    (df[[ratio_206_204]] - a0) / (exp(l238 * t0) - exp(l238 * result$model_age_SK75))
+  )
+
+  result$kappa_SK75 <-  ifelse(
+    is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]) | is.na(df[[ratio_208_204]]),
+    NA_real_,
+    (df[[ratio_208_204]] - c0) / (result$mu_SK75 * (exp(l232 * t0) - exp(l232 * result$model_age_SK75)))
+  )
+
+  result$model_age_SK75 <- result$model_age_SK75 * 10^-6
+  result <- round(result, 3)
 
   if (inherits(df, "ASTR")) {
     df_out <- cbind(get_contextual_columns(df), df[c(ratio_206_204, ratio_207_204, ratio_208_204)], result)
@@ -183,6 +199,8 @@ stacey_kramers_1975 <- function(df,
   } else {
     df_out <- cbind(df, result)
   }
+
+
 
   return(df_out)
 }
@@ -226,17 +244,31 @@ cumming_richards_1975 <- function(df,
     )$minimum
   }
 
+  result <- data.frame("model_age_CR75" = rep(NA, nrow(df)), "mu_CR75" = NA, "kappa_CR75" = NA)
+
   # Calculation and clean-up
 
-  model_age <- mapply(model_age_func, df[[ratio_206_204]], df[[ratio_207_204]])
+  result$model_age_CR75 <- ifelse(
+    is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]),
+    NA_real_,
+    mapply(model_age_func, df[[ratio_206_204]], df[[ratio_207_204]])
+  )
 
-  model_age <- replace(model_age, model_age <= -10001 * 10^6 | model_age >= t0 - 1 * 10^6, NA)
+  result$model_age_CR75 <- replace(result$model_age_CR75, result$model_age_CR75 <= -10001 *10^6 | result$model_age_CR75 >= t0 - 1 * 10^6, NA)
 
-  mu <- 137.88 * vp * (1 - e1 * model_age)
-  kappa <- wp * (1 - e2 * model_age) / mu
+  result$mu_CR75 <-  ifelse(
+    is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]),
+    NA_real_,
+    137.88 * vp * (1 - e1 * result$model_age_CR75)
+  )
+  result$kappa_CR75 <-  ifelse(
+    is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]),
+    NA_real_,
+    wp * (1 - e2 * result$model_age_CR75) / result$mu_CR75
+  )
 
-  result <- data.frame("model_age_CR75" = model_age * 10^-6, "mu_CR75" = mu, "kappa_CR75" = kappa) %>%
-    round(3)
+  result$model_age_CR75 <- result$model_age_CR75 * 10^-6
+  result <- round(result, 3)
 
   if (inherits(df, "ASTR")) {
     df_out <- cbind(get_contextual_columns(df), df[c(ratio_206_204, ratio_207_204, ratio_208_204)], result)
@@ -296,14 +328,31 @@ albarede_juteau_1984 <- function(df,
     }
   }
 
+  result <- data.frame("model_age_AJ84" = rep(NA, nrow(df)), "mu_AJ84" = NA, "kappa_AJ84" = NA)
+
   # Calculation and clean-up
 
   roots <- mapply(model_age_func, df[[ratio_206_204]], df[[ratio_207_204]])
 
-  kappa <- (df[[ratio_208_204]] - zstar0) / (exp(l232 * t0) - exp(l232 * roots[1, ])) / roots[2, ]
+  result$model_age_AJ84 <- ifelse(
+    is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]) | is.na(df[[ratio_208_204]]),
+    NA_real_,
+    roots[1, ] * 10^-6
+  )
 
-  result <- data.frame("model_age_AJ84" = roots[1, ] * 10^-6, "mu_AJ84" = roots[2, ], "kappa_AJ84" = kappa) %>%
-    round(3)
+  result$mu_AJ84 <-  ifelse(
+    is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]) | is.na(df[[ratio_208_204]]),
+    NA_real_,
+    roots[2, ]
+  )
+
+  result$kappa_AJ84 <-  ifelse(
+    is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]) | is.na(df[[ratio_208_204]]),
+    NA_real_,
+    (df[[ratio_208_204]] - zstar0) / (exp(l232 * t0) - exp(l232 * roots[1, ])) / roots[2, ]
+  )
+
+  result <- round(result, 3)
 
   if (inherits(df, "ASTR")) {
     df_out <- cbind(get_contextual_columns(df), df[c(ratio_206_204, ratio_207_204, ratio_208_204)], result)

--- a/R/ASTR_PbIso_AgeModels.R
+++ b/R/ASTR_PbIso_AgeModels.R
@@ -169,17 +169,20 @@ stacey_kramers_1975 <- function(df,
     is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]) | is.na(df[[ratio_208_204]]),
     NA_real_,
     mapply(model_age_func, df[[ratio_206_204]], df[[ratio_207_204]])
-    )
+  )
 
-  result$model_age_SK75 <- replace(result$model_age_SK75, result$model_age_SK75 <= -10001 * 10^6 | result$model_age_SK75 >= t0 - 1 * 10^6, NA)
+  result$model_age_SK75 <- replace(
+    result$model_age_SK75, result$model_age_SK75 <= -10001 * 10^6 | result$model_age_SK75 >= t0 - 1 * 10^6,
+    NA
+  )
 
-  result$mu_SK75 <-  ifelse(
+  result$mu_SK75 <- ifelse(
     is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]) | is.na(df[[ratio_208_204]]),
     NA_real_,
     (df[[ratio_206_204]] - a0) / (exp(l238 * t0) - exp(l238 * result$model_age_SK75))
   )
 
-  result$kappa_SK75 <-  ifelse(
+  result$kappa_SK75 <- ifelse(
     is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]) | is.na(df[[ratio_208_204]]),
     NA_real_,
     (df[[ratio_208_204]] - c0) / (result$mu_SK75 * (exp(l232 * t0) - exp(l232 * result$model_age_SK75)))
@@ -199,7 +202,6 @@ stacey_kramers_1975 <- function(df,
   } else {
     df_out <- cbind(df, result)
   }
-
 
 
   return(df_out)
@@ -232,9 +234,8 @@ cumming_richards_1975 <- function(df,
   model_age_func <- function(x, y) {
     stats::optimize(
       function(s, a, b) {
-        (a0 - a + 137.88 * vp *
-           ((exp(l238 * t0) * (1 - e1 * (t0 - 1 / l238))) -
-              (exp(l238 * s) * (1 - e1 * (s - 1 / l238)))))^2 +
+        (a0 - a + 137.88 * vp * ((exp(l238 * t0) * (1 - e1 * (t0 - 1 / l238))) -
+                                   (exp(l238 * s) * (1 - e1 * (s - 1 / l238)))))^2 +
           (b0 - b + vp * ((exp(l235 * t0) * (1 - e1 * (t0 - 1 / l235))) -
                             (exp(l235 * s) * (1 - e1 * (s - 1 / l235)))))^2
       },
@@ -254,14 +255,17 @@ cumming_richards_1975 <- function(df,
     mapply(model_age_func, df[[ratio_206_204]], df[[ratio_207_204]])
   )
 
-  result$model_age_CR75 <- replace(result$model_age_CR75, result$model_age_CR75 <= -10001 *10^6 | result$model_age_CR75 >= t0 - 1 * 10^6, NA)
+  result$model_age_CR75 <- replace(
+    result$model_age_CR75, result$model_age_CR75 <= -10001 * 10^6 | result$model_age_CR75 >= t0 - 1 * 10^6,
+    NA
+  )
 
-  result$mu_CR75 <-  ifelse(
+  result$mu_CR75 <- ifelse(
     is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]),
     NA_real_,
     137.88 * vp * (1 - e1 * result$model_age_CR75)
   )
-  result$kappa_CR75 <-  ifelse(
+  result$kappa_CR75 <- ifelse(
     is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]),
     NA_real_,
     wp * (1 - e2 * result$model_age_CR75) / result$mu_CR75
@@ -340,13 +344,13 @@ albarede_juteau_1984 <- function(df,
     roots[1, ] * 10^-6
   )
 
-  result$mu_AJ84 <-  ifelse(
+  result$mu_AJ84 <- ifelse(
     is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]) | is.na(df[[ratio_208_204]]),
     NA_real_,
     roots[2, ]
   )
 
-  result$kappa_AJ84 <-  ifelse(
+  result$kappa_AJ84 <- ifelse(
     is.na(df[[ratio_206_204]]) | is.na(df[[ratio_207_204]]) | is.na(df[[ratio_208_204]]),
     NA_real_,
     (df[[ratio_208_204]] - zstar0) / (exp(l232 * t0) - exp(l232 * roots[1, ])) / roots[2, ]

--- a/tests/testthat/test_PbIso_age_models.R
+++ b/tests/testthat/test_PbIso_age_models.R
@@ -1,7 +1,7 @@
 age_model_data <- tibble::tibble(
-  `206Pb/204Pb` = 18,
-  `207Pb/204Pb` = 15,
-  `208Pb/204Pb` = 2
+  `206Pb/204Pb` = c(18, NA, 18),
+  `207Pb/204Pb` = c(15, 15, NA),
+  `208Pb/204Pb` = c(2, NA, 2)
 )
 
 suppressWarnings(
@@ -15,12 +15,13 @@ suppressWarnings(
 age_models_ASTR <- pb_iso_age_model(test_input, model = "all")
 
 test_that("Pb isotope age models", {
-  expect_equal(pb_iso_age_model(age_model_data, model = "SK75")[["model_age_SK75"]], -1166.946)
-  expect_equal(pb_iso_age_model(age_model_data, model = "CR75")[["mu_CR75"]], 10.478)
-  expect_equal(pb_iso_age_model(age_model_data, model = "AJ84")[["kappa_AJ84"]], -15.421)
+  expect_equal(pb_iso_age_model(age_model_data, model = "SK75")[["model_age_SK75"]][1], -1166.946)
+  expect_equal(pb_iso_age_model(age_model_data, model = "CR75")[["mu_CR75"]][1], 10.478)
+  expect_equal(pb_iso_age_model(age_model_data, model = "AJ84")[["kappa_AJ84"]][1], -15.421)
   expect_error(pb_iso_age_model(age_model_data, model = 23), "'arg' must be.*")
   expect_error(pb_iso_age_model(age_model_data, model = "23"), "'arg' should be one of.*")
   expect_length(pb_iso_age_model(age_model_data, model = "all"), 12)
+  expect_equal(pb_iso_age_model(age_model_data, model = "AJ84")[["kappa_AJ84"]][3], NA_real_)
 })
 
 test_that("ASTR objects handled as intended", {


### PR DESCRIPTION
The functions to calculate the lead isotope age model parameters now return `NA` for all parameters if one of the input ratios is `NA`. 

Follow-up on feedback gathered at the CAA (https://github.com/archaeothommy/ASTR/issues/43)